### PR TITLE
inputs.aws-ecr-repository does not need to be assigned to an environm…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,16 +21,11 @@ runs:
   steps:
     - uses: actions/checkout@v1
 
-    - name: Setup environment
-      run: |
-        echo "AWS_ECR_REPOSITORY=${{ inputs.aws-ecr-repository }}" >> $GITHUB_ENV
-      shell: bash
-
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Create the repository
-      run: |
-        aws ecr describe-repositories --repository-names ${AWS_ECR_REPOSITORY} || aws ecr create-repository --repository-name ${AWS_ECR_REPOSITORY}
       shell: bash
+      run: |
+        aws ecr describe-repositories --repository-names ${{ inputs.aws-ecr-repository }} || aws ecr create-repository --repository-name ${{ inputs.aws-ecr-repository }}


### PR DESCRIPTION
…ent variable

### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ * ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- Fixes # inputs.aws-ecr-repository does not need to be assigned to an environment variable
